### PR TITLE
Add config service selector flag

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,1 +1,6 @@
+
+# Config service url
 REACT_APP_CONFIG_SERVICE_URL=https://safe-config.safe.global
+
+# Shows the Config service url selector if true
+REACT_APP_SHOW_CONFIG_SERVICE_SELECTOR=true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,8 @@ import Header from "src/components/header/Header";
 import ConfigServiceUrlSelector from "src/components/config-service-url-selector/ConfigServiceUrlSelector";
 import ChainStatusTable from "src/components/chain-status-table/ChainStatusTable";
 
-const { REACT_APP_CONFIG_SERVICE_URL } = process.env;
+const { REACT_APP_CONFIG_SERVICE_URL, REACT_APP_SHOW_CONFIG_SERVICE_SELECTOR } =
+  process.env;
 
 function App() {
   const [configServiceUrl, setConfigServiceUrl] = useState<string>(
@@ -24,12 +25,18 @@ function App() {
       {/* App header */}
       <Header isDarkTheme={isDarkTheme} switchThemeMode={switchThemeMode} />
 
-      <Container maxWidth="lg" component="main" sx={{ marginBottom: "32px" }}>
+      <Container
+        maxWidth="lg"
+        component="main"
+        sx={{ marginBottom: "36px", marginTop: "42px" }}
+      >
         {/* Config service selector */}
-        <ConfigServiceUrlSelector
-          configServiceUrl={configServiceUrl}
-          setConfigServiceUrl={setConfigServiceUrl}
-        />
+        {showConfigServiceSelector && (
+          <ConfigServiceUrlSelector
+            configServiceUrl={configServiceUrl}
+            setConfigServiceUrl={setConfigServiceUrl}
+          />
+        )}
 
         {/* Chain status table */}
         <ChainStatusTable configServiceUrl={configServiceUrl} />
@@ -39,3 +46,6 @@ function App() {
 }
 
 export default App;
+
+const showConfigServiceSelector =
+  REACT_APP_SHOW_CONFIG_SERVICE_SELECTOR === "true";


### PR DESCRIPTION
Added a new `REACT_APP_SHOW_CONFIG_SERVICE_SELECTOR` environment variable to show/hide the Config service url selector:

- In `Stage`: `REACT_APP_SHOW_CONFIG_SERVICE_SELECTOR=true`
- In `Production`: `REACT_APP_SHOW_CONFIG_SERVICE_SELECTOR=false`



![Captura de pantalla 2023-01-26 a las 13 21 22](https://user-images.githubusercontent.com/26763673/214834994-424c8495-a150-47d9-972b-72867ae1536e.png)
